### PR TITLE
I made a fix for older Firefox versions

### DIFF
--- a/js/onmediaquery.js
+++ b/js/onmediaquery.js
@@ -48,7 +48,7 @@ var MQ = (function(mq) {
         }
 
         if (window.getComputedStyle) {
-            query_string = window.getComputedStyle(document.documentElement).getPropertyValue('font-family');
+            query_string = window.getComputedStyle(document.documentElement,null).getPropertyValue('font-family');
         }
 
         // No support for CSS enumeration? Return and avoid errors.


### PR DESCRIPTION
getComputedStyle threw a javascript error in older versions of Firefox because the second parameter wasn't included. More info here: http://caniuse.com/#search=getComputedStyle. The fix doesn't seem to throw a new error in other browsers.

Signed-off-by: Wout Mager wout@woutmager.nl
