### PR TITLE
fix an error of varible declaration  and an error in older versions of IE

### DIFF
--- a/index.html
+++ b/index.html
@@ -280,9 +280,23 @@ window.onload = function() {
 			console.log( 'second skinny callback!' )
 		}
 	});
+	
+	//Add a media query test
+	var my_query = MQ.addQuery({
+		context: 'skinny', 
+		match: function() { 
+			console.log( 'second skinny callback!' )
+		}
+	});
+	var callbacklen = MQ.callbacks.length;
+	//Remove a media query test by reference
+	MQ.removeQuery( my_query );
+	if(callbacklen - MQ.callbacks.length === 1){
+		console.log("RemoveQuery test success");
+	}else{
+		console.log("RemoveQuery test failture");
+	}
 }
-
-
 
 </script> 
 <!-- End scripts -->

--- a/js/onmediaquery.js
+++ b/js/onmediaquery.js
@@ -192,33 +192,34 @@ var MQ = (function(mq) {
         }
         return false;
     };
-	
-	/**
+    
+    /**
      * IE8 do not supports Array.properties.indexOf
-	 * in lieu of jQuery.
+     * copy from jQuery.
+     * in lieu of jQuery.
      * @returns int
      */
-	mq._indexOf = function( elem, arr, i ) {
-		var len;
-
-		if ( arr ) {
-			if ( arr.indexOf ) {
-				return arr.indexOf( elem, i );
-			}
-
-			len = arr.length;
-			i = i ? i < 0 ? Math.max( 0, len + i ) : i : 0;
-
-			for ( ; i < len; i++ ) {
-				// Skip accessing in sparse arrays
-				if ( i in arr && arr[ i ] === elem ) {
-					return i;
-				}
-			}
-		}
-
-		return -1;
-	}
+    mq._indexOf = function( elem, arr, i ) 
+    {
+        var len;
+        if ( arr ) {
+            if ( arr.indexOf ) {
+                return arr.indexOf( elem, i );
+            }
+            
+            len = arr.length;
+            i = i ? i < 0 ? Math.max( 0, len + i ) : i : 0;
+            
+            for ( ; i < len; i++ ) {
+                // Skip accessing in sparse arrays
+                if ( i in arr && arr[ i ] === elem ) {
+                    return i;
+                }
+            }
+        }
+        
+        return -1;
+    }
 
     // Expose the functions.
     return mq;

--- a/js/onmediaquery.js
+++ b/js/onmediaquery.js
@@ -40,7 +40,7 @@ var MQ = (function(mq) {
      * @returns Void(0)
      */
     mq.listenForChange = function() {
-        var body_after;
+        var query_string;
 
         // Get the value of html { font-family } from the element style.
         if (document.documentElement.currentStyle) {

--- a/js/onmediaquery.js
+++ b/js/onmediaquery.js
@@ -110,7 +110,7 @@ var MQ = (function(mq) {
 
         var match = -1;
 
-        while ((match = this.callbacks.indexOf(query_object)) > -1) {
+        while ((match = mq._indexOf(query_object,this.callbacks)) > -1) {
             this.callbacks.splice(match, 1);
         }
     };
@@ -192,6 +192,33 @@ var MQ = (function(mq) {
         }
         return false;
     };
+	
+	/**
+     * IE8 do not supports Array.properties.indexOf
+	 * in lieu of jQuery.
+     * @returns int
+     */
+	mq._indexOf = function( elem, arr, i ) {
+		var len;
+
+		if ( arr ) {
+			if ( arr.indexOf ) {
+				return arr.indexOf( elem, i );
+			}
+
+			len = arr.length;
+			i = i ? i < 0 ? Math.max( 0, len + i ) : i : 0;
+
+			for ( ; i < len; i++ ) {
+				// Skip accessing in sparse arrays
+				if ( i in arr && arr[ i ] === elem ) {
+					return i;
+				}
+			}
+		}
+
+		return -1;
+	}
 
     // Expose the functions.
     return mq;


### PR DESCRIPTION
Error of varible declaration : 
There is a variable declared but never used in function mq.listenForChange.
I think is maybe a error, I change variable name to query_string.

Error in older versions of IE
MQ.removeQuery threw a null error in older version of IE because old IE not support Array.properties.indexOf. more info here: http://kangax.github.io/es5-compat-table/#Array.prototype.indexOf . the fix does'nt seem to throw a new error in other browsers.
